### PR TITLE
Don't use hard-coded path to raco & racket. Save pid.

### DIFF
--- a/server-startup.sh
+++ b/server-startup.sh
@@ -4,5 +4,6 @@
 
 git fetch
 git reset --hard origin/stable
-/home/ubuntu/racket/bin/raco make compiler-service.rkt
-/usr/bin/nohup /home/ubuntu/racket/bin/racket compiler-service.rkt  --extra-module-provider wescheme-module-provider.rkt &
+raco make compiler-service.rkt
+/usr/bin/nohup racket compiler-service.rkt  --extra-module-provider wescheme-module-provider.rkt &
+echo $! > /tmp/wescheme-compiler.pid


### PR DESCRIPTION
To make it easier to use local racket installations and monit, save
the pid to the /tmp directory.
